### PR TITLE
Removed loop from position_gen

### DIFF
--- a/brownian_generate.py
+++ b/brownian_generate.py
@@ -49,11 +49,10 @@ def start_seed(particle_width):
 def position_gen(r):
     center_x, center_y = (width / 2), (height / 2)
     rand_x, rand_y = -1, -1
-    while (rand_x - center_x) ** 2 + (rand_y - center_y) ** 2 != r ** 2:
-        angle = 2 * math.pi * random.random()
-        rand_x = r * math.cos(angle) + center_x
-        rand_y = r * math.sin(angle) + center_y
-    return (rand_x, rand_y)
+    angle = 2 * math.pi * random.random()
+    rand_x = r * math.cos(angle) + center_x
+    rand_y = r * math.sin(angle) + center_y
+    return (rand_x, rand_y) 
 
 # Returns a tuple of (x, y) coordinates after random walk with constraints
 def next_move(particle, r):

--- a/config.cfg
+++ b/config.cfg
@@ -1,8 +1,8 @@
 [SIM_SETTINGS]
 width = 805
 height = 805
-particle-number = 20000
-particle-width = 1
+particle-number = 1000
+particle-width = 3
 set-random-seed = 
 stick-chance = 1
 color-list = [(130, 46, 129), (142, 220, 230), (239, 48, 84), (213, 111, 62)]


### PR DESCRIPTION
It seems like the only time this loop condition is satisfied is rounding errors. The trig should always return a point close enough to the radius